### PR TITLE
Add a `public_name` field to the `u2f` library stanza

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build/
+_opam

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,6 @@
 (library
  (name u2f)
+ (public_name u2f)
  (preprocess
   (pps ppx_deriving_yojson))
  (libraries mirage-crypto-rng yojson mirage-crypto-ec x509 base64))


### PR DESCRIPTION
This field is necessary to tell Dune to include this library as part of `dune install`. Without this, the library isn't visible to users installing `u2f` via e.g. `opam`.

A side-effect of this change is that `dune build @doc` will now generate the documentation for this library correctly.